### PR TITLE
Add ABCL to -list for +EXTERNAL-FORMAT+

### DIFF
--- a/config.lisp
+++ b/config.lisp
@@ -8,7 +8,7 @@
 ;;; depending on your Lisp implementation/OS/installation.
 
 (defconstant +external-format+
-  #-(or sbcl lispworks clisp allegro ccl) :default
+  #-(or sbcl lispworks clisp allegro ccl abcl) :default
   #+abcl '(:iso-8859-1 :eol-style :lf)
   #+ecl '(:latin-1 :lf)
   #+ccl :latin1


### PR DESCRIPTION
By the looks of it ECL needs to be added to the list as well I can't
test this unfortunately.