### PR TITLE
Be more tolerant when parsing PDFs

### DIFF
--- a/pdf.lisp
+++ b/pdf.lisp
@@ -28,7 +28,8 @@
   (push (cons name value)(dict-values dict)))
 
 (defun get-dict-value (dict name)
-  (cdr (assoc name (dict-values dict) :test #'string=)))
+  (when dict
+   (cdr (assoc name (dict-values dict) :test #'string=))))
 
 (defun change-dict-value (dict name value)
   (let ((key-val (assoc name (dict-values dict) :test #'string=)))


### PR DESCRIPTION
I was using with-existing-document/with-existing-page to modify a document which turned out not to have any top-level /Resources.  This was a problem for open-page, which tries to use those resources as a dictionary.  The rest of open-page is aware that resources may be NIL and recovers gracefully, but never got that far because get-dict-value threw an error.  This simple patch avoids the error by making get-dict-value a bit more tolerant of its input.