### PR TITLE
Added ability to construct pdf without keeping the contents of all images in memory

### DIFF
--- a/config.lisp
+++ b/config.lisp
@@ -90,3 +90,6 @@
 (defvar *a4-landscape-page-bounds* #(0 0 841 595))
 (defvar *letter-landscape-page-bounds* #(0 0 792 612))
 (defvar *default-page-bounds* *a4-portrait-page-bounds*)
+
+
+(defvar *load-images-lazily* nil)

--- a/defpackage.lisp
+++ b/defpackage.lisp
@@ -15,6 +15,7 @@
    #:*letter-portrait-page-bounds* #:*letter-landscape-page-bounds*
    #:*a4-portrait-page-bounds* #:*a4-landscape-page-bounds*
    #:*default-page-bounds*
+   #:bounds #:*load-images-lazily*
    #:load-fonts #:get-font #:font #:clear-font-cache #:name #:encoding #:font-metrics #:add-font-to-page
    #:font-name #:full-name #:family-name #:weight #:font-bbox #:*version* #:notice #:encoding-scheme
    #:characters #:code #:width #:bbox #:kernings #:get-font-descender

--- a/pdf-base.lisp
+++ b/pdf-base.lisp
@@ -399,7 +399,7 @@
                        (error-message condition))))))
 
 (defclass jpeg-image (bitmap-image)
-  ())
+  ((filename :accessor filename :initarg :filename)))
 
 (defun %read-jpeg-file% (filename &key header-only)
   (with-open-file (s filename :direction :input :element-type '(unsigned-byte 8))
@@ -435,6 +435,7 @@
       (%read-jpeg-file% filename :header-only header-only)
     (when nb-components
       (make-instance 'jpeg-image :nb-components nb-components
+		     :filename filename
 		     :width width :height height :data data))))
 
 (defgeneric make-jpeg-image (jpeg))
@@ -468,5 +469,6 @@
          :bits (data jpeg)
          :width (width jpeg) :height (height jpeg)
          :filter "/DCTDecode"
+	 :filename (filename jpeg)
          :color-space (aref +jpeg-color-spaces+ (nb-components jpeg))
          :no-compression t))


### PR DESCRIPTION

The feature is enabled by setting pdf:*load-images-lazily* to t . It
currently only works for jpg images but could be extended to any image
with a filename.

