### PR TITLE
Allow copying and removing pages in templates

### DIFF
--- a/pdf-parser.lisp
+++ b/pdf-parser.lisp
@@ -490,6 +490,16 @@ Returns the first unused object-number."
       (change-dict-value dict "/Contents" *current-content*))
     page))
 
+(defun remove-page (page-num)
+  (let ((page (aref (pages *root-page*) page-num)))
+    (setf (pages *root-page*)
+	  (remove page (pages *root-page*)))
+    (change-dict-value (content *root-page*) "/Count" #'(lambda () (length (pages *root-page*))))
+    (change-dict-value (content *root-page*) "/Kids" (pages *root-page*))))
+
+
+(export 'remove-page)
+
 (defmacro with-existing-document ((file &key (creator "") author title subject keywords) &body body)
   `(let* ((*document* (read-pdf-file ,file))
 	  (*root-page* (root-page *document*))

--- a/pdf.lisp
+++ b/pdf.lisp
@@ -37,6 +37,11 @@
 	(setf (cdr key-val) value)
 	(add-dict-value dict name value))))
 
+(defun copy-dict (dict)
+  (when dict
+    (make-instance 'dictionary
+		   :dict-values (copy-alist (dict-values dict)))))
+
 (defclass pdf-stream (dictionary)
   ((content :accessor content :initform "" :initarg :content)
    (no-compression :accessor no-compression :initarg :no-compression :initform nil)))


### PR DESCRIPTION
I want to use a two-page template (first- and follow-on-pages) to generate single, two- or multipage output.  This required changes to pdf-parser.lisp.

To achieve my goals I extended the signature of with-existing-page to take a new keyword parameter copy-p.  If nil, the existing template page is edited, as before.  If non-nil, a copy of the page is inserted at the end of the document.

To remove unneeded template pages, I added a new exported function remove-page.

Perhaps someone else also finds this useful.  I make no claims that the code is optimal, I do not really understand the structure of PDFs or the cl-pdf representation of it.  But through trial and error, this seemed to do the job I wanted it to.