### PR TITLE
copy-page: copy the content dictionary

### DIFF
--- a/pdf-parser.lisp
+++ b/pdf-parser.lisp
@@ -497,7 +497,7 @@ Returns the first unused object-number."
 	 (fonts (copy-dict (ensure-dictionary (get-dict-value resources "/Font"))))
 	 (xobjects (copy-dict (ensure-dictionary (get-dict-value resources "/XObject"))))
 	 (new-page (make-instance 'page))
-	 (new-dict (content new-page))
+	 (new-dict (setf (content new-page) (copy-dict src-dict)))
 	 (content-stream (make-instance 'pdf-stream)))
     (setf *original-content* (get-dict-value src-dict "/Contents"))
     (setf *current-content* (make-array 10 :fill-pointer 0 :adjustable t))


### PR DESCRIPTION
Fixes a bug with the new copy-page function.  Using with-existing-page with :copy-p nil on a page previously copied through with-existing-page with :copy-p t would get the wrong bounds.  The reason for that was that the page copy did not replicate the /MediaBox dict value from the source page.

To make the copy an actual copy, the entire (content src-page)-dictionary should be copied over, in case there is more interesting stuff there than just the /MediaBox.