### PR TITLE
more png surport and other image format support by conversion

### DIFF
--- a/cl-pdf.asd
+++ b/cl-pdf.asd
@@ -63,4 +63,4 @@
                (:file "bar-codes" :depends-on ("pdf-geom"))
                (:file "chart" :depends-on ("text" "pdf-geom"))
                (:file "zzinit" :depends-on ("config")))
-  :depends-on (:iterate #+use-salza-zlib :salza #+use-salza2-zlib :salza2 :zpb-ttf))
+  :depends-on (:iterate #+use-salza-zlib :salza #+use-salza2-zlib :salza2 :zpb-ttf :uiop))

--- a/png.lisp
+++ b/png.lisp
@@ -173,3 +173,10 @@
                          ("/BitsPerComponent" . ,(bits-per-color png))
                          ("/Columns" . ,(width png)))
          :no-compression t)))				; data bits already come compressed
+
+(defun read-png-file2 (pathname &key header-only)
+  (handler-case
+      (read-png-file pathname :header-only header-only)
+    (image-file-parse-error (err)
+      (or (read-convert-jpg-file pathname :header-only header-only)
+	  err))))


### PR DESCRIPTION
When I was trying to run example11, I found cl-pdf can't load some of png files (e.g. ![f_0](https://cloud.githubusercontent.com/assets/13259400/17077067/7a8692b6-50f5-11e6-9d34-06d06c148880.png) )  and image file formats other than jpg/jpeg. This commit first try to read jpg or png files by original cl-pdf functions, when image-file-parse-error occurs, it try to use imagemagick (command line tool) to convert the image into a jpg file in the temp folder and load the converted version. This doesn't bother if cl-pdf can already load the image but enable it to load any files support by imagemagick (static gif, tif, bmp, etc.). I have tried some more lispy approach, such as try load the file by cl-png or png-read, but after load the example png file, I found its :color-space slot is not supported by cl-pdf's png reader and both cl-png and png-read can't convert :color-space.
