### PR TITLE
Format library version independently of *READ-DEFAULT-FLOAT-FORMAT*

### DIFF
--- a/pdf.lisp
+++ b/pdf.lisp
@@ -161,7 +161,7 @@
   (setf (docinfo doc) (make-instance 'indirect-object))
   (setf (content (docinfo doc))
         (make-instance 'dictionary
-                       :dict-values `(("/Creator" . ,(format nil "(cl-pdf ~A~@[ - ~A~])"
+                       :dict-values `(("/Creator" . ,(format nil "(cl-pdf ~,2F~@[ - ~A~])"
                                                              *version* creator))
                                       ,@(when author `(("/Author" . ,(format nil "(~A)" author))))
                                       ,@(when title `(("/Title" . ,(format nil "(~A)" title))))


### PR DESCRIPTION
Before this change, the format control string `~A` was used to format the library version stored in `*version*`. Since that variable is defined as

```common-lisp
(defparameter *version* 2.03)
```

the value is either a `single-float` or a `double-float`, depending on the value of `*read-default-float-format*` at the time the cl-pdf source code is read. In case the value of `*read-default-float-format*` at runtime differs from the earlier value, `~A` prints a float exponent marker (`f` or `d`) which is confusing.