### PR TITLE
Draw centered image

### DIFF
--- a/defpackage.lisp
+++ b/defpackage.lisp
@@ -40,7 +40,8 @@
    #:set-gray-stroke #:set-gray-fill #:set-rgb-stroke #:set-rgb-fill #:set-cymk-stroke
    #:set-color-stroke #:set-color-fill
    #:set-transparency #:set-fill-transparency #:set-stroke-transparency
-   #:set-cymk-fill #:paint-image #:draw-image #:get-named-reference #:register-page-reference
+   #:set-cymk-fill #:paint-image #:draw-image #:draw-centered-image
+   #:get-named-reference #:register-page-reference
    #:add-link #:add-URI-link #:add-external-link #:read-jpeg-file #:make-jpeg-image
    #:make-image #:width #:height
    #:enter-outline-level #:close-outline-level #:with-outline-level

--- a/pdf-base.lisp
+++ b/pdf-base.lisp
@@ -340,17 +340,24 @@
   (set-gstate "CA" (format nil "~3F" alpha)))
 
 (defun draw-image (image x y dx dy rotation &optional keep-aspect-ratio)
+  "Paint an image at (`x`,`y`), after rotating it counterclockwise by `rotation` degrees and scaling
+   it to `dx`X`dy` points (subject to the `keep-aspect-ratio` boolean).
+
+   Note that the rotation is actually accomplished by rotating the page clockwise, so the (`x`,`y`)
+   coordinates point to the 'logical' left-bottom corner of the image.
+   I.e.: with (= rotation 0) they are the coordinates of the leftmost and bottommost point of the
+   image, while, e.g., with (= rotation 180) they mark the rightmost and topmost point."
   (when keep-aspect-ratio
     (let ((r1 (/ dy dx))
-	  (r2 (/ (height image)(width image))))
-      (if (> r1 r2)
-	(setf dy (* dx r2)))
-	(when (< r1 r2)(setf dx (/ dy r2)))))
+          (r2 (/ (height image) (width image))))
+      (cond
+        ((> r1 r2) (setf dy (* dx r2)))
+        ((< r1 r2) (setf dx (/ dy r2))))))
   (with-saved-state
-      (translate x y)
-      (rotate rotation)
-      (scale dx dy)
-      (paint-image image)))
+    (translate x y)
+    (rotate rotation)
+    (scale dx dy)
+    (paint-image image)))
 
 (defun draw-centered-image (image x y dx dy rotation &optional keep-aspect-ratio)
   "Paint an image centered at (`x`,`y`) after rotating it counterclockwise by `rotation` degrees

--- a/pdf-base.lisp
+++ b/pdf-base.lisp
@@ -352,6 +352,27 @@
       (scale dx dy)
       (paint-image image)))
 
+(defun draw-centered-image (image x y dx dy rotation &optional keep-aspect-ratio)
+  "Paint an image centered at (`x`,`y`) after rotating it counterclockwise by `rotation` degrees
+   and scaling it to `dx`X`dy` points (subject to the `keep-aspect-ratio` boolean)."
+  (when keep-aspect-ratio
+    (let ((r1 (/ dy dx))
+          (r2 (/ (height image) (width image))))
+      (cond
+        ((> r1 r2) (setf dy (* dx r2)))
+        ((< r1 r2) (setf dx (/ dy r2))))))
+  (let* ((radians (* rotation (/ pi 180)))
+         (dx0 (/ dx 2))
+         (dy0 (/ dy 2))
+         (radius (sqrt (+ (* dx0 dx0) (* dy0 dy0))))
+         (x (+ x (* radius (cos (- radians (acos (- (/ dx0 radius))))))))
+         (y (- y (* radius (sin (- radians (asin (- (/ dy0 radius)))))))))
+    (with-saved-state
+      (translate x y)
+      (rotate rotation)
+      (scale dx dy)
+      (paint-image image))))
+
 (defun add-link (x y dx dy ref-name &key (border #(0 0 0)))
   (let ((annotation (make-instance 'annotation :rect (vector x y (+ x dx) (+ y dy))
 				   :type "/Link" :border border)))


### PR DESCRIPTION
A new function for drawing an image centered at a given point.
This could also be accomplished by adding another optional parameter to draw-image, but I feel like its lambda list is already long enough and draw-centered-image seems a nice companion for draw-centered-text.
Feel free to amend the patch (or let me know and I will gladly do) if you think adding a parameter is a more sensible solution.