### PR TITLE
Existing Document Information Dictionary was ignored when running pdf:with-existing-document

### DIFF
--- a/pdf-parser.lisp
+++ b/pdf-parser.lisp
@@ -538,7 +538,7 @@ Returns the first unused object-number."
 
 (export 'remove-page)
 
-(defmacro with-existing-document ((file &key (creator "") author title subject keywords) &body body)
+(defmacro with-existing-document ((file &key creator author title subject keywords) &body body)
   `(let* ((*document* (read-pdf-file ,file))
 	  (*root-page* (root-page *document*))
 	  (*page-number* 0)

--- a/pdf.lisp
+++ b/pdf.lisp
@@ -158,21 +158,20 @@
 
 (defun add-doc-info (doc &key creator author title subject keywords
                               creation-date modification-date)
-  (setf (docinfo doc) (make-instance 'indirect-object))
-  (setf (content (docinfo doc))
-        (make-instance 'dictionary
-                       :dict-values `(("/Creator" . ,(format nil "(cl-pdf ~,2F~@[ - ~A~])"
-                                                             *version* creator))
-                                      ,@(when author `(("/Author" . ,(format nil "(~A)" author))))
-                                      ,@(when title `(("/Title" . ,(format nil "(~A)" title))))
-                                      ,@(when subject `(("/Subject" . ,(format nil "(~A)" subject))))
-                                      ,@(when keywords `(("/Keywords" . ,(format nil "(~A)" keywords))))
-                                      ,@(when creation-date
-                                          `(("/CreationDate" . ,(human-readable-time<-universal-time
-                                                                 (universal-time<-time-spec creation-date)))))
-                                      ,@(when modification-date
-                                          `(("/ModDate" . ,(human-readable-time<-universal-time
-                                                            (universal-time<-time-spec modification-date)))))))))
+  (let* ((info (or (docinfo doc) (make-instance 'indirect-object)))
+	 (dict (or (content info) (make-instance 'dictionary))))
+    (setf (docinfo doc) info)
+    (setf (content info) dict)
+    (when creator (change-dict-value dict "/Creator" (format nil "(cl-pdf ~,2F~@[ - ~A~])" *version* creator)))
+    (when author (change-dict-value dict "/Author" (format nil "(~A)" author)))
+    (when title (change-dict-value dict "/Title" (format nil "(~A)" title)))
+    (when subject (change-dict-value dict "/Subject" (format nil "(~A)" subject)))
+    (when keywords (change-dict-value dict "/Keywords" (format nil "(~A)" keywords)))
+    (when creation-date (change-dict-value dict "/CreationDate" (human-readable-time<-universal-time
+								 (universal-time<-time-spec creation-date))))
+    (when modification-date (change-dict-value dict "/ModDate" (human-readable-time<-universal-time
+								(universal-time<-time-spec modification-date))))
+    dict))
 
 (defclass indirect-object ()
   ((obj-number :accessor obj-number :initform (incf (last-object-number *document*)) :initarg :obj-number)


### PR DESCRIPTION
#### Problem

At the moment, when running `pdf:with-existing-document`, the library calls `pdf::add-doc-info` that ignores the existing docinfo and replaces it with a new dictionary. The current behavior prevents the developer from reading the existing doc info.

#### Solution

Modify `pdf::add-doc-info` to only create a new dictionary in case the Document doesn't have one, and only replace the values when the developer provides them.

#### Notes

The current version of `pdf:with-existing-document` has a default value for the `creator` key set to `""`. In order to make the creator optional, I've decided to no longer set a default value for the `creator`.

_I'm very new to Common Lisp, feedback is welcome!_