### PR TITLE
READ-NAME & WRITE-OBJECT supports extended-ascii

### DIFF
--- a/config.lisp
+++ b/config.lisp
@@ -14,8 +14,7 @@
   #+clasp :iso-8859-1
   #+ccl :latin1
   #+sbcl :latin-1
-  #+(and allegro mswindows) :octets
-  #+(and allegro unix) :default
+  #+allegro :octets
   #+lispworks '(:latin-1 :eol-style :lf)
   #+clisp (ext:make-encoding :charset 'charset:iso-8859-1 :line-terminator :unix))
 

--- a/pdf.lisp
+++ b/pdf.lisp
@@ -571,7 +571,16 @@
             else do (write-byte (char-external-code char *default-charset*) *pdf-stream*))
       (write-string obj *pdf-stream*))
   #-(and lispworks pdf-binary)
-  (write-string obj *pdf-stream*))
+  (if (char= #\/ (aref obj 0))          ; When obj is a NAME
+      (loop for char across obj
+	 if (or (whitespace-p char)     ; white or extended-ascii
+		(extended-ascii-p char))
+	 do
+	   (format *pdf-stream* "#~2,'0x" (char-code char))
+	 else do
+              (write-char char *pdf-stream*))
+      ;; When obj is a STRING
+    (write-string obj *pdf-stream*)))
 
 (defmethod write-object ((obj symbol) &optional root-level)
   (declare (ignorable root-level))


### PR DESCRIPTION
#+allegro +EXTERNAL-FORMAT+ should be :OCTETS on both unix & windows platform.
READ-NAME & WRITE-OBJECT supports extended-ascii.
FILE-LENGTH can be smaller than +XREF-SEARCH-SIZE+.