### PR TITLE
Move extended-ascii-p definition to pdf.lisp

### DIFF
--- a/pdf-parser.lisp
+++ b/pdf-parser.lisp
@@ -105,9 +105,6 @@
   (and (<= #x21 (char-code char) #x7E)
        (not (find char "%()<>[]{}/#"))))
 
-(defun extended-ascii-p (char)
-  (<= 128 (char-code char) 253))
-
 ;;; Skipping characters
 
 (defun eat-char (expected-char)

--- a/pdf.lisp
+++ b/pdf.lisp
@@ -561,6 +561,9 @@
     (write-object obj)
     (write-char #\Space *pdf-stream*)))
 
+(defun extended-ascii-p (char)
+  (<= 128 (char-code char) 253))
+
 (defmethod write-object ((obj string) &optional root-level)
   (declare (ignorable root-level))
   #+(and lispworks pdf-binary)


### PR DESCRIPTION
This is to avoid an 'undefined function' exception when using :cl-pdf without :cl-pdf-parser. The latter still works as it depends on the former.